### PR TITLE
Add static 404 page and specify Node 22

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
+      <h1 className="text-4xl font-bold">404 - Page Not Found</h1>
+      <p className="text-lg">The page you are looking for does not exist.</p>
+      <Link href="/" className="text-blue-600 hover:underline">
+        Return home
+      </Link>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "portfolio",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- add static 404 page so build does not rely on dynamic intl APIs
- declare Node 22 runtime in package.json to match Vercel recommendations

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b87b720988832884bd0a936c7cdd62